### PR TITLE
[wip] Initial implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+- '0.10'
+- 4
+- 5

--- a/lib/dimensions.js
+++ b/lib/dimensions.js
@@ -1,0 +1,6 @@
+export default elm => ({
+  width: parseInt(elm.getAttribute('width') || elm.style.width, 10) ||
+    undefined,
+  height: parseInt(elm.getAttribute('height') || elm.style.height, 10) ||
+    undefined
+});

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,29 @@
+import * as image from './types/image';
+import * as video from './types/video';
+import * as youtube from './types/youtube';
+import * as twitter from './types/twitter';
+import * as instagram from './types/instagram';
+import * as facebook from './types/facebook';
+import * as vine from './types/vine';
+import * as custom from './types/custom';
+
+const types = [
+  image, video, youtube, twitter, instagram, facebook, vine,
+  custom /* last element */
+];
+
+export const parse = elements => {
+  if (elements && !Array.isArray(elements)) {
+    elements = [elements];
+  }
+  if (elements && elements.length) {
+    for (let i = 0; i < types.length; i++) {
+      let type = types[i];
+      let results = type.parse(elements);
+      if (results) {
+        return results;
+      }
+    }
+  }
+  return null;
+};

--- a/lib/types/custom.js
+++ b/lib/types/custom.js
@@ -1,0 +1,18 @@
+import url from 'url';
+import getDimensions from '../dimensions';
+
+export const parse = ([elm]) => {
+  if (elm.tagName.toLowerCase() !== 'iframe') {
+    return null;
+  }
+
+  const src = elm.getAttribute('src');
+  const {width, height} = getDimensions(elm);
+  if (!src || !width || !height) {
+    return null;
+  }
+
+  const parsed = url.parse(src, false, true);
+  const secure = parsed.protocol === 'https:';
+  return { type: 'custom', width, height, src, secure };
+};

--- a/lib/types/custom.js
+++ b/lib/types/custom.js
@@ -13,6 +13,6 @@ export const parse = ([elm]) => {
   }
 
   const parsed = url.parse(src, false, true);
-  const secure = parsed.protocol === 'https:';
+  const secure = parsed.protocol === 'https:' || parsed.protocol === null;
   return { type: 'custom', width, height, src, secure };
 };

--- a/lib/types/facebook.js
+++ b/lib/types/facebook.js
@@ -1,0 +1,22 @@
+const type = 'facebook';
+
+const parseElm = elm => {
+  if (!elm.classList.contains('fb-post') && !elm.classList.contains('fb-video')) {
+    return null;
+  }
+
+  const url = elm.getAttribute('data-href');
+  const embedAs = elm.classList.contains('fb-video') ? 'video' : 'post';
+
+  return { embedAs, type, url };
+};
+
+export const parse = elements => {
+  for (let i = 0; i < elements.length; ++i) {
+    let results = parseElm(elements[i]);
+    if (results) {
+      return results;
+    }
+  }
+  return null;
+};

--- a/lib/types/image.js
+++ b/lib/types/image.js
@@ -1,0 +1,28 @@
+import getDimensions from '../dimensions';
+
+const createImage = (img) => {
+  const {width, height} = getDimensions(img);
+
+  return {
+    type: 'image',
+    src: img.getAttribute('src'),
+    alt: img.getAttribute('alt') || undefined,
+    width, height
+  };
+};
+
+export const parse = ([elm]) => {
+  const tagName = elm.tagName.toLowerCase();
+
+  if (tagName === 'figure') {
+    const img = elm.getElementsByTagName('img')[0];
+
+    if (img) {
+      return createImage(img);
+    }
+  } else if (tagName === 'img') {
+    return createImage(elm);
+  }
+
+  return null;
+};

--- a/lib/types/image.js
+++ b/lib/types/image.js
@@ -1,27 +1,17 @@
 import getDimensions from '../dimensions';
 
-const createImage = (img) => {
-  const {width, height} = getDimensions(img);
-
-  return {
-    type: 'image',
-    src: img.getAttribute('src'),
-    alt: img.getAttribute('alt') || undefined,
-    width, height
-  };
-};
-
 export const parse = ([elm]) => {
   const tagName = elm.tagName.toLowerCase();
 
-  if (tagName === 'figure') {
-    const img = elm.getElementsByTagName('img')[0];
+  if (tagName === 'img') {
+    const {width, height} = getDimensions(elm);
 
-    if (img) {
-      return createImage(img);
-    }
-  } else if (tagName === 'img') {
-    return createImage(elm);
+    return {
+      type: 'image',
+      src: elm.getAttribute('src'),
+      alt: elm.getAttribute('alt') || undefined,
+      width, height
+    };
   }
 
   return null;

--- a/lib/types/instagram.js
+++ b/lib/types/instagram.js
@@ -1,0 +1,44 @@
+import last from 'lodash.last';
+
+const type = 'instagram';
+
+function testInstagramMediaEmbed (elm) {
+  if (!elm.classList.contains('instagram-media')) {
+    return null;
+  }
+
+  const paragraphs = elm.getElementsByTagName('p');
+  if (!paragraphs[0]) {
+    return null;
+  }
+
+  const postLink = paragraphs[0].getElementsByTagName('a')[0];
+  const text = elm.hasAttribute('data-instgrm-captioned')
+    ? postLink.childNodes[0].data : null;
+  const url = postLink.getAttribute('href');
+  const id = last(url.split('/').filter(Boolean));
+
+  return { type, text, url, id };
+}
+
+const regexp = /https?:\/\/instagram\.com\/p\/([A-Za-z0-9_-]+)\/embed/;
+
+function testInstagramIframe (elm) {
+  if (elm.tagName.toLowerCase() !== 'iframe') {
+    return null;
+  }
+
+  const url = elm.getAttribute('src') || '';
+  const match = url.match(regexp);
+  if (!match) {
+    return null;
+  }
+
+  const id = match[1];
+
+  return { type, text: '', url: `https://instagram.com/p/${id}`, id };
+}
+
+export const parse = ([elm]) => {
+  return testInstagramMediaEmbed(elm) || testInstagramIframe(elm);
+};

--- a/lib/types/twitter.js
+++ b/lib/types/twitter.js
@@ -1,0 +1,66 @@
+import find from 'lodash.find';
+import last from 'lodash.last';
+import map from 'lodash.map';
+
+const type = 'twitter';
+
+const getText = elm => {
+  const pElm = elm.getElementsByTagName('p')[0];
+  if (!pElm) {
+    return [];
+  }
+
+  return map(pElm.childNodes, (child) => {
+    if (child.nodeName === '#text') {
+      return {
+        content: child.data,
+        href: null
+      };
+    }
+
+    if (child.tagName.toLowerCase() === 'a') {
+      return {
+        content: child.childNodes[0].data,
+        href: child.getAttribute('href')
+      };
+    }
+  }).filter(Boolean);
+};
+
+const getUser = elm => {
+  const userElm = find(elm.childNodes, child => child.nodeName === '#text');
+  if (!userElm) {
+    return {
+      name: null,
+      slug: null
+    };
+  }
+  const userString = userElm.data;
+  const lastIndex = userString.lastIndexOf('(');
+  const userName = userString.slice(2, lastIndex).trim();
+  const userSlug = userString.slice(lastIndex + 2, -2);
+
+  return {
+    name: userName,
+    slug: userSlug
+  };
+};
+
+export const parse = ([elm]) => {
+  if (!elm.classList.contains('twitter-tweet')) {
+    return null;
+  }
+
+  const aElm = last(elm.getElementsByTagName('a'));
+  const url = aElm.getAttribute('href');
+  const id = last(url.split('/').filter(Boolean));
+  const date = aElm.childNodes.length > 0 ? aElm.childNodes[0].data : '';
+  const user = getUser(elm);
+  const text = getText(elm);
+
+  if (!/^\d+$/.test(id)) {
+    return null;
+  }
+
+  return { user, date, text, id, url, type };
+};

--- a/lib/types/video.js
+++ b/lib/types/video.js
@@ -1,0 +1,45 @@
+import getDimensions from '../dimensions';
+import map from 'lodash.map';
+
+const type = 'video';
+
+const getSources = elm => {
+  const sourceElms = elm.getElementsByTagName('source');
+
+  if (sourceElms.length) {
+    return map(sourceElms, sourceElm => ({
+      src: sourceElm.getAttribute('src'),
+      type: sourceElm.getAttribute('type') || null
+    }));
+  }
+
+  return [{
+    src: elm.getAttribute('src'),
+    type: null
+  }];
+};
+
+export const parse = ([elm]) => {
+  let tagName = elm.tagName.toLowerCase();
+
+  if (tagName === 'figure') {
+    elm = elm.getElementsByTagName('video')[0];
+
+    if (!elm) {
+      return null;
+    }
+
+    tagName = elm.tagName.toLowerCase();
+  }
+
+  if (tagName === 'video') {
+    const {width, height} = getDimensions(elm);
+    const sources = getSources(elm);
+
+    return {
+      type, sources, width, height
+    };
+  }
+
+  return null;
+};

--- a/lib/types/video.js
+++ b/lib/types/video.js
@@ -22,16 +22,6 @@ const getSources = elm => {
 export const parse = ([elm]) => {
   let tagName = elm.tagName.toLowerCase();
 
-  if (tagName === 'figure') {
-    elm = elm.getElementsByTagName('video')[0];
-
-    if (!elm) {
-      return null;
-    }
-
-    tagName = elm.tagName.toLowerCase();
-  }
-
   if (tagName === 'video') {
     const {width, height} = getDimensions(elm);
     const sources = getSources(elm);

--- a/lib/types/vine.js
+++ b/lib/types/vine.js
@@ -1,0 +1,30 @@
+import startsWith from 'lodash.startswith';
+import { parse as parseEmbedly } from 'embedly-url';
+
+const type = 'vine';
+
+const checkSrc = src => startsWith(src, 'https://vine.co/v/');
+const regexp = /https:\/\/vine\.co\/v\/([^\/]+)/;
+
+export const parse = ([elm]) => {
+  if (elm.tagName.toLowerCase() !== 'iframe') {
+    return null;
+  }
+
+  const src = elm.getAttribute('src');
+  if (!src) {
+    return null;
+  }
+
+  const embedlyParsed = parseEmbedly(src);
+
+  const url = embedlyParsed ? embedlyParsed.src : src;
+  if (!checkSrc(url)) {
+    return null;
+  }
+
+  const match = url.match(regexp);
+  const id = match[1];
+
+  return { type, url, id };
+};

--- a/lib/types/youtube.js
+++ b/lib/types/youtube.js
@@ -4,16 +4,6 @@ import getYoutubeId from 'get-youtube-id';
 export const parse = ([elm]) => {
   let tagName = elm.tagName.toLowerCase();
 
-  if (tagName === 'figure') {
-    elm = elm.getElementsByTagName('iframe')[0];
-
-    if (!elm) {
-      return null;
-    }
-
-    tagName = elm.tagName.toLowerCase();
-  }
-
   if (tagName !== 'iframe') {
     return null;
   }

--- a/lib/types/youtube.js
+++ b/lib/types/youtube.js
@@ -1,0 +1,33 @@
+import { parse as parseEmbedly } from 'embedly-url';
+import getYoutubeId from 'get-youtube-id';
+
+export const parse = ([elm]) => {
+  let tagName = elm.tagName.toLowerCase();
+
+  if (tagName === 'figure') {
+    elm = elm.getElementsByTagName('iframe')[0];
+
+    if (!elm) {
+      return null;
+    }
+
+    tagName = elm.tagName.toLowerCase();
+  }
+
+  if (tagName !== 'iframe') {
+    return null;
+  }
+
+  const src = elm.getAttribute('src');
+  if (!src) {
+    return null;
+  }
+
+  const embedlyParsed = parseEmbedly(src);
+  const youtubeId = embedlyParsed
+    ? getYoutubeId(embedlyParsed.src) : getYoutubeId(src);
+  return youtubeId && {
+    type: 'youtube',
+    youtubeId
+  };
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Parse & render embeds",
   "main": "dist/index.js",
   "scripts": {
-    "test": "ava && semistandard | snazzy",
+    "test": "nyc ava && semistandard | snazzy",
     "prepublish": "mkdir -p dist && babel lib --out-dir dist"
   },
   "repository": {
@@ -21,10 +21,22 @@
   },
   "homepage": "https://github.com/micnews/embeds#readme",
   "devDependencies": {
+    "ava": "^0.13.0",
     "babel-cli": "^6.6.5",
     "babel-core": "^6.7.2",
     "babel-preset-es2015": "^6.6.0",
+    "nyc": "^6.1.1",
+    "query-dom": "^3.0.7",
     "semistandard": "^7.0.5",
-    "snazzy": "^3.0.0"
+    "snazzy": "^3.0.0",
+    "tsml": "^1.0.1"
+  },
+  "dependencies": {
+    "embedly-url": "^1.0.0",
+    "get-youtube-id": "^1.0.0",
+    "lodash.find": "^4.2.0",
+    "lodash.last": "^3.0.0",
+    "lodash.map": "^4.2.1",
+    "lodash.startswith": "^4.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -24,6 +24,19 @@ test('parse() img', t => {
   t.same(actual, expected);
 });
 
+test('parse() single element', t => {
+  const elm = queryDom('<img src="http://example.com/image.jpg" />')[0];
+  const actual = _parse(elm);
+  const expected = {
+    type: 'image',
+    src: 'http://example.com/image.jpg',
+    width: undefined,
+    height: undefined,
+    alt: undefined
+  };
+  t.same(actual, expected);
+});
+
 test('parse() img, with alt-attribute', t => {
   const actual = parse('<img src="http://example.com/image.jpg" alt="beep boop" />');
   const expected = {

--- a/test.js
+++ b/test.js
@@ -1,0 +1,436 @@
+import test from 'ava';
+import 'babel-core/register';
+import {parse as _parse} from './lib';
+import queryDom from 'query-dom';
+import tsml from 'tsml';
+
+const parse = str => _parse(queryDom(str));
+
+test('parse() empty', t => {
+  const actual = parse('');
+  const expected = null;
+  t.same(actual, expected);
+});
+
+test('parse() img', t => {
+  const actual = parse('<img src="http://example.com/image.jpg" />');
+  const expected = {
+    type: 'image',
+    src: 'http://example.com/image.jpg',
+    width: undefined,
+    height: undefined,
+    alt: undefined
+  };
+  t.same(actual, expected);
+});
+
+test('parse() img, with alt-attribute', t => {
+  const actual = parse('<img src="http://example.com/image.jpg" alt="beep boop" />');
+  const expected = {
+    type: 'image',
+    src: 'http://example.com/image.jpg',
+    width: undefined,
+    height: undefined,
+    alt: 'beep boop'
+  };
+  t.same(actual, expected);
+});
+
+test('parse() img with width & height', t => {
+  const input = tsml`<img src="http://example.com/image.jpg" width="100" height="200" />`;
+  const actual = parse(input);
+  const expected = {
+    type: 'image',
+    src: 'http://example.com/image.jpg',
+    width: 100,
+    height: 200,
+    alt: undefined
+  };
+
+  t.same(actual, expected);
+});
+
+test('parse() img with width & height css', t => {
+  const input = tsml`<img src="http://example.com/image.jpg" style="width: 100; height: 200" />`;
+  const actual = parse(input);
+  const expected = {
+    type: 'image',
+    src: 'http://example.com/image.jpg',
+    width: 100,
+    height: 200,
+    alt: undefined
+  };
+
+  t.same(actual, expected);
+});
+
+test('parse() video with src', t => {
+  const input = '<video src="http://example.com/video.mp4" />';
+  const actual = parse(input);
+  const expected = {
+    type: 'video',
+    sources: [{
+      src: 'http://example.com/video.mp4',
+      type: null
+    }],
+    width: undefined,
+    height: undefined
+  };
+  t.same(actual, expected);
+});
+
+test('parse() video with sources', t => {
+  const input = tsml`<video>
+    <source src="http://example.com/video.mp4" />
+    <source src="http://example.com/video2.mp4" type="video/mp4"/>
+  </video>`;
+  const actual = parse(input);
+  const expected = {
+    type: 'video',
+    sources: [{
+      src: 'http://example.com/video.mp4',
+      type: null
+    }, {
+      src: 'http://example.com/video2.mp4',
+      type: 'video/mp4'
+    }],
+    width: undefined,
+    height: undefined
+  };
+  t.same(actual, expected);
+});
+
+test('parse() video with width & height', t => {
+  const input = '<video src="http://example.com/video.mp4" width="100" height="200" />';
+  const actual = parse(input);
+  const expected = {
+    type: 'video',
+    sources: [{
+      src: 'http://example.com/video.mp4',
+      type: null
+    }],
+    width: 100,
+    height: 200
+  };
+  t.same(actual, expected);
+});
+
+test('parse() video with width & height css', t => {
+  const input = '<video src="http://example.com/video.mp4" style="width:100;height:200" />';
+  const actual = parse(input);
+  const expected = {
+    type: 'video',
+    sources: [{
+      src: 'http://example.com/video.mp4',
+      type: null
+    }],
+    width: 100,
+    height: 200
+  };
+  t.same(actual, expected);
+});
+
+test('parse() figure + video with src', t => {
+  const input = '<figure><video src="http://example.com/video.mp4" /></figure>';
+  const actual = parse(input);
+  const expected = {
+    type: 'video',
+    sources: [{
+      src: 'http://example.com/video.mp4',
+      type: null
+    }],
+    width: undefined,
+    height: undefined
+  };
+  t.same(actual, expected);
+});
+
+test('parse() figure + video with sources', t => {
+  const input = tsml`<figure>
+    <video>
+      <source src="http://example.com/video.mp4" />
+      <source src="http://example.com/video2.mp4" type="video/mp4"/>
+    </video>
+  </figure>`;
+  const actual = parse(input);
+  const expected = {
+    type: 'video',
+    sources: [{
+      src: 'http://example.com/video.mp4',
+      type: null
+    }, {
+      src: 'http://example.com/video2.mp4',
+      type: 'video/mp4'
+    }],
+    width: undefined,
+    height: undefined
+  };
+  t.same(actual, expected);
+});
+
+test('parse() figure + video with src & figcaption', t => {
+  const input = `<figure>
+    <video src="http://example.com/video.mp4"></video>
+  </figure>`;
+  const actual = parse(input);
+  const expected = {
+    type: 'video',
+    sources: [{
+      src: 'http://example.com/video.mp4',
+      type: null
+    }],
+    width: undefined,
+    height: undefined
+  };
+  t.same(actual, expected);
+});
+
+test('parse() youtube iframe', t => {
+  const input = `<iframe src="https://www.youtube.com/embed/pDVmldTurqk"></iframe>`;
+  const actual = parse(input);
+  const expected = {
+    type: 'youtube',
+    youtubeId: 'pDVmldTurqk'
+  };
+  t.same(actual, expected);
+});
+
+test('parse() youtube embedly iframe', t => {
+  const input = `<iframe
+    src="//cdn.embedly.com/widgets/media.html?src=http%3A%2F%2Fwww.youtube.com%2Fembed%2F3rS6mZUo3fg%3Ffeature%3Doembed"
+  ></iframe>`;
+  const actual = parse(input);
+  const expected = {
+    type: 'youtube',
+    youtubeId: '3rS6mZUo3fg'
+  };
+  t.same(actual, expected);
+});
+
+test('parse() figure + youtube iframe', t => {
+  const input = `<figure>
+    <iframe src="https://www.youtube.com/embed/pDVmldTurqk"></iframe>
+    <figcaption>Hello, <b>world</b></figcaption>
+  </figure>`;
+  const actual = parse(input);
+  const expected = {
+    type: 'youtube',
+    youtubeId: 'pDVmldTurqk'
+  };
+  t.same(actual, expected);
+});
+
+test('parse() tweet - normal', t => {
+  const input = `<blockquote class="twitter-tweet" lang="en"><p lang="en" dir="ltr">GIF vs. JIF… This <a href="https://t.co/qFAHWgdbL6">pic.twitter.com/qFAHWgdbL6</a></p>&mdash; Matt (foo) Navarra (@MattNavarra) <a href="https://twitter.com/MattNavarra/status/684690494841028608">January 6, 2016</a></blockquote><script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>`;
+  const actual = parse(input);
+  const expected = {
+    type: 'twitter',
+    text: [
+      { content: 'GIF vs. JIF… This ', href: null },
+      { content: 'pic.twitter.com/qFAHWgdbL6', href: 'https://t.co/qFAHWgdbL6' }
+    ],
+    url: 'https://twitter.com/MattNavarra/status/684690494841028608',
+    date: 'January 6, 2016',
+    user: {
+      slug: 'MattNavarra',
+      name: 'Matt (foo) Navarra'
+    },
+    id: '684690494841028608'
+  };
+  t.same(actual, expected);
+});
+
+test('parse() tweet - no date', t => {
+  const input = `<blockquote class="twitter-tweet" lang="en"><p lang="en" dir="ltr">GIF vs. JIF… This <a href="https://t.co/qFAHWgdbL6">pic.twitter.com/qFAHWgdbL6</a></p>&mdash; Matt (foo) Navarra (@MattNavarra) <a href="https://twitter.com/MattNavarra/status/684690494841028608"></a></blockquote><script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>`;
+  const actual = parse(input);
+  const expected = {
+    type: 'twitter',
+    text: [
+      { content: 'GIF vs. JIF… This ', href: null },
+      { content: 'pic.twitter.com/qFAHWgdbL6', href: 'https://t.co/qFAHWgdbL6' }
+    ],
+    url: 'https://twitter.com/MattNavarra/status/684690494841028608',
+    date: '',
+    user: {
+      slug: 'MattNavarra',
+      name: 'Matt (foo) Navarra'
+    },
+    id: '684690494841028608'
+  };
+  t.same(actual, expected);
+});
+
+test('parse() tweet - weird input', t => {
+  const input = `<blockquote class="twitter-tweet" lang="en"><p lang="en" dir="ltr">foo bar<beep>boop</beep></p>&mdash; Matt Navarra (@MattNavarra) <a href="https://twitter.com/MattNavarra/status/684690494841028608">January 6, 2016</a></blockquote><script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>`;
+  const actual = parse(input).text;
+  const expected = [
+    { content: 'foo bar', href: null }
+  ];
+  t.same(actual, expected);
+});
+
+test('parse() tweet - no paragraph, no user', t => {
+  const input = `<blockquote class="twitter-tweet" lang="en"><a href="https://twitter.com/MattNavarra/status/684690494841028608">January 6, 2016</a></blockquote><script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>`;
+  const actual = parse(input);
+  const expected = {
+    type: 'twitter',
+    text: [],
+    url: 'https://twitter.com/MattNavarra/status/684690494841028608',
+    date: 'January 6, 2016',
+    user: {
+      slug: null,
+      name: null
+    },
+    id: '684690494841028608'
+  };
+  t.same(actual, expected);
+});
+
+test('parse() tweet - no id', t => {
+  const input = `<blockquote class="twitter-tweet" lang="en"><p lang="en" dir="ltr">GIF vs. JIF… This <a href="https://t.co/qFAHWgdbL6">pic.twitter.com/qFAHWgdbL6</a></p>&mdash; Matt (foo) Navarra (@MattNavarra) </blockquote><script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>`;
+  const actual = parse(input);
+  const expected = null;
+  t.same(actual, expected);
+});
+
+test('parse() instagram http iframe', t => {
+  const input = `<iframe src="http://instagram.com/p/fdx1CSuEPV/embed"></iframe>`;
+  const actual = parse(input);
+  const expected = {
+    type: 'instagram',
+    text: '',
+    id: 'fdx1CSuEPV',
+    url: 'https://instagram.com/p/fdx1CSuEPV'
+  };
+  t.same(actual, expected);
+});
+
+test('parse() instagram https iframe', t => {
+  const input = `<iframe src="https://instagram.com/p/fdx1CSuEPV/embed"></iframe>`;
+  const actual = parse(input);
+  const expected = {
+    type: 'instagram',
+    text: '',
+    id: 'fdx1CSuEPV',
+    url: 'https://instagram.com/p/fdx1CSuEPV'
+  };
+  t.same(actual, expected);
+});
+
+test('parse() instagram - with caption', t => {
+  const input = `<blockquote class="instagram-media" data-instgrm-captioned data-instgrm-version="6" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:658px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);"><div style="padding:8px;"> <div style=" background:#F8F8F8; line-height:0; margin-top:40px; padding:50.0% 0; text-align:center; width:100%;"> <div style=" background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAsCAMAAAApWqozAAAAGFBMVEUiIiI9PT0eHh4gIB4hIBkcHBwcHBwcHBydr+JQAAAACHRSTlMABA4YHyQsM5jtaMwAAADfSURBVDjL7ZVBEgMhCAQBAf//42xcNbpAqakcM0ftUmFAAIBE81IqBJdS3lS6zs3bIpB9WED3YYXFPmHRfT8sgyrCP1x8uEUxLMzNWElFOYCV6mHWWwMzdPEKHlhLw7NWJqkHc4uIZphavDzA2JPzUDsBZziNae2S6owH8xPmX8G7zzgKEOPUoYHvGz1TBCxMkd3kwNVbU0gKHkx+iZILf77IofhrY1nYFnB/lQPb79drWOyJVa/DAvg9B/rLB4cC+Nqgdz/TvBbBnr6GBReqn/nRmDgaQEej7WhonozjF+Y2I/fZou/qAAAAAElFTkSuQmCC); display:block; height:44px; margin:0 auto -44px; position:relative; top:-22px; width:44px;"></div></div> <p style=" margin:8px 0 0 0; padding:0 4px;"> <a href="https://www.instagram.com/p/-7PIhyA6J3/" style=" color:#000; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none; word-wrap:break-word;" target="_blank">Reinsta @karinn In Berlin. Feeling awesome.</a></p> <p style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; line-height:17px; margin-bottom:0; margin-top:8px; overflow:hidden; padding:8px 0 7px; text-align:center; text-overflow:ellipsis; white-space:nowrap;">A photo posted by David Björklund (@david_bjorklund) on <time style=" font-family:Arial,sans-serif; font-size:14px; line-height:17px;" datetime="2015-12-05T21:40:53+00:00">Dec 5, 2015 at 1:40pm PST</time></p></div></blockquote><script async defer src="//platform.instagram.com/en_US/embeds.js"></script>`;
+  const actual = parse(input);
+  const expected = {
+    type: 'instagram',
+    id: '-7PIhyA6J3',
+    url: 'https://www.instagram.com/p/-7PIhyA6J3/',
+    text: 'Reinsta @karinn In Berlin. Feeling awesome.'
+  };
+  t.same(actual, expected);
+});
+
+test('parse() instagram - without caption', t => {
+  const input = `<blockquote class="instagram-media" data-instgrm-version="6" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:658px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);"><div style="padding:8px;"> <div style=" background:#F8F8F8; line-height:0; margin-top:40px; padding:50.0% 0; text-align:center; width:100%;"> <div style=" background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAsCAMAAAApWqozAAAAGFBMVEUiIiI9PT0eHh4gIB4hIBkcHBwcHBwcHBydr+JQAAAACHRSTlMABA4YHyQsM5jtaMwAAADfSURBVDjL7ZVBEgMhCAQBAf//42xcNbpAqakcM0ftUmFAAIBE81IqBJdS3lS6zs3bIpB9WED3YYXFPmHRfT8sgyrCP1x8uEUxLMzNWElFOYCV6mHWWwMzdPEKHlhLw7NWJqkHc4uIZphavDzA2JPzUDsBZziNae2S6owH8xPmX8G7zzgKEOPUoYHvGz1TBCxMkd3kwNVbU0gKHkx+iZILf77IofhrY1nYFnB/lQPb79drWOyJVa/DAvg9B/rLB4cC+Nqgdz/TvBbBnr6GBReqn/nRmDgaQEej7WhonozjF+Y2I/fZou/qAAAAAElFTkSuQmCC); display:block; height:44px; margin:0 auto -44px; position:relative; top:-22px; width:44px;"></div></div><p style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; line-height:17px; margin-bottom:0; margin-top:8px; overflow:hidden; padding:8px 0 7px; text-align:center; text-overflow:ellipsis; white-space:nowrap;"><a href="https://www.instagram.com/p/-7PIhyA6J3/" style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none;" target="_blank">A photo posted by David Björklund (@david_bjorklund)</a> on <time style=" font-family:Arial,sans-serif; font-size:14px; line-height:17px;" datetime="2015-12-05T21:40:53+00:00">Dec 5, 2015 at 1:40pm PST</time></p></div></blockquote><script async defer src="//platform.instagram.com/en_US/embeds.js"></script>`;
+  const actual = parse(input);
+  const expected = {
+    type: 'instagram',
+    id: '-7PIhyA6J3',
+    url: 'https://www.instagram.com/p/-7PIhyA6J3/',
+    text: null
+  };
+  t.same(actual, expected);
+});
+
+test('parse() instagram - bad input', t => {
+  const input = `<blockquote class="instagram-media" data-instgrm-captioned data-instgrm-version="6" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:658px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);"></blockquote>`;
+  const actual = parse(input);
+  const expected = null;
+  t.same(actual, expected);
+});
+
+test('parse() facebook - post', t => {
+  const input = tsml`
+    <div id="fb-root"></div>
+    <script>(function(d, s, id) {  var js, fjs = d.getElementsByTagName(s)[0];  if (d.getElementById(id)) return;  js = d.createElement(s); js.id = id;  js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.3";  fjs.parentNode.insertBefore(js, fjs);}(document, \'script\', \'facebook-jssdk\'));</script>
+    <div class="fb-post" data-href="https://www.facebook.com/david.bjorklund/posts/10153809692501070" data-width="500">
+      <div class="fb-xfbml-parse-ignore">
+        <blockquote cite="https://www.facebook.com/david.bjorklund/posts/10153809692501070">
+          <p>Hey!So, for the last few weeks I&#039;ve worked on http://mic.com/ - the new home for mic.com (on desktop) - please take a look :)</p>
+          Posted by <a href="#" role="button">David Pop Hipsterson</a> on&nbsp;<a href="https://www.facebook.com/david.bjorklund/posts/10153809692501070">Thursday, January 21, 2016</a>
+        </blockquote>
+      </div>
+    </div>`;
+  const actual = parse(input);
+  const expected = {
+    url: 'https://www.facebook.com/david.bjorklund/posts/10153809692501070',
+    type: 'facebook',
+    embedAs: 'post'
+  };
+  t.same(actual, expected);
+});
+
+test('parse() facebook - video', t => {
+  const input = '<div id="fb-root"></div><script>(function(d, s, id) {  var js, fjs = d.getElementsByTagName(s)[0];  if (d.getElementById(id)) return;  js = d.createElement(s); js.id = id;  js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.3";  fjs.parentNode.insertBefore(js, fjs);}(document, \'script\', \'facebook-jssdk\'));</script><div class="fb-video" data-allowfullscreen="1" data-href="https://www.facebook.com/MicMedia/videos/1060315987324524/"><div class="fb-xfbml-parse-ignore"><blockquote cite="https://www.facebook.com/MicMedia/videos/1060315987324524/"><a href="https://www.facebook.com/MicMedia/videos/1060315987324524/">Why is breastfeeding in public such a big deal?</a><p>Men and women *both* have nipples — so why do we only shame women for showing theirs... especially when they&#039;re breastfeeding?</p>Posted by <a href="https://www.facebook.com/MicMedia/">Mic</a> on Friday, January 15, 2016</blockquote></div></div>';
+  const actual = parse(input);
+  const expected = {
+    url: 'https://www.facebook.com/MicMedia/videos/1060315987324524/',
+    type: 'facebook',
+    embedAs: 'video'
+  };
+  t.same(actual, expected);
+});
+
+test('parse() vine', t => {
+  const input = '<iframe src="https://vine.co/v/bjHh0zHdgZT/embed/simple" width="600" height="600" frameborder="0"></iframe><script src="https://platform.vine.co/static/scripts/embed.js"></script>';
+  const actual = parse(input);
+  const expected = {
+    id: 'bjHh0zHdgZT',
+    type: 'vine',
+    url: 'https://vine.co/v/bjHh0zHdgZT/embed/simple'
+  };
+  t.same(actual, expected);
+});
+
+test('parse() vine embedly', t => {
+  const input = '<iframe class="embedly-embed" src="//cdn.embedly.com/widgets/media.html?src=https%3A%2F%2Fvine.co%2Fv%2FbjHh0zHdgZT%2Fembed%2Fsimple&amp;url=https%3A%2F%2Fvine.co%2Fv%2FbjHh0zHdgZT%2Fembed%2Fsimple&amp;image=https%3A%2F%2Fv.cdn.vine.co%2Fr%2Fthumbs%2F8B474922-0D0E-49AD-B237-6ED46CE85E8A-118-000000FFCD48A9C5_1.0.6.mp4.jpg%3FversionId%3D5mzXl2DXYBvKvF9rhcp.nvEJC.1N86RG&amp;key=25bf3602073943478e54668402a4f5a8&amp;type=text%2Fhtml&amp;schema=vine" width="600" height="600" scrolling="no" frameborder="0" allowfullscreen=""></iframe>';
+  const actual = parse(input);
+  const expected = {
+    id: 'bjHh0zHdgZT',
+    type: 'vine',
+    url: 'https://vine.co/v/bjHh0zHdgZT/embed/simple'
+  };
+  t.same(actual, expected);
+});
+
+test('parse() iframe no src', t => {
+  const input = '<iframe class="embedly-embed" width="600" height="600" scrolling="no" frameborder="0" allowfullscreen=""></iframe>';
+  const actual = parse(input);
+  const expected = null;
+  t.same(actual, expected);
+});
+
+test('parse() custom embed', t => {
+  const input = '<iframe src="http://custom.com" width="600" height="600" frameborder="0"></iframe>';
+  const actual = parse(input);
+  const expected = {
+    type: 'custom',
+    src: 'http://custom.com',
+    width: 600,
+    height: 600,
+    secure: false
+  };
+  t.same(actual, expected);
+});
+
+test('parse() custom secure embed', t => {
+  const input = '<iframe src="https://custom.com" width="600" height="600" frameborder="0"></iframe>';
+  const actual = parse(input);
+  const expected = {
+    type: 'custom',
+    src: 'https://custom.com',
+    width: 600,
+    height: 600,
+    secure: true
+  };
+  t.same(actual, expected);
+});

--- a/test.js
+++ b/test.js
@@ -379,3 +379,16 @@ test('parse() custom secure embed', t => {
   };
   t.same(actual, expected);
 });
+
+test('parse() custom secure embed with no protocol', t => {
+  const input = '<iframe src="//custom.com" width="600" height="600" frameborder="0"></iframe>';
+  const actual = parse(input);
+  const expected = {
+    type: 'custom',
+    src: '//custom.com',
+    width: 600,
+    height: 600,
+    secure: true
+  };
+  t.same(actual, expected);
+});

--- a/test.js
+++ b/test.js
@@ -130,61 +130,6 @@ test('parse() video with width & height css', t => {
   t.same(actual, expected);
 });
 
-test('parse() figure + video with src', t => {
-  const input = '<figure><video src="http://example.com/video.mp4" /></figure>';
-  const actual = parse(input);
-  const expected = {
-    type: 'video',
-    sources: [{
-      src: 'http://example.com/video.mp4',
-      type: null
-    }],
-    width: undefined,
-    height: undefined
-  };
-  t.same(actual, expected);
-});
-
-test('parse() figure + video with sources', t => {
-  const input = tsml`<figure>
-    <video>
-      <source src="http://example.com/video.mp4" />
-      <source src="http://example.com/video2.mp4" type="video/mp4"/>
-    </video>
-  </figure>`;
-  const actual = parse(input);
-  const expected = {
-    type: 'video',
-    sources: [{
-      src: 'http://example.com/video.mp4',
-      type: null
-    }, {
-      src: 'http://example.com/video2.mp4',
-      type: 'video/mp4'
-    }],
-    width: undefined,
-    height: undefined
-  };
-  t.same(actual, expected);
-});
-
-test('parse() figure + video with src & figcaption', t => {
-  const input = `<figure>
-    <video src="http://example.com/video.mp4"></video>
-  </figure>`;
-  const actual = parse(input);
-  const expected = {
-    type: 'video',
-    sources: [{
-      src: 'http://example.com/video.mp4',
-      type: null
-    }],
-    width: undefined,
-    height: undefined
-  };
-  t.same(actual, expected);
-});
-
 test('parse() youtube iframe', t => {
   const input = `<iframe src="https://www.youtube.com/embed/pDVmldTurqk"></iframe>`;
   const actual = parse(input);
@@ -203,19 +148,6 @@ test('parse() youtube embedly iframe', t => {
   const expected = {
     type: 'youtube',
     youtubeId: '3rS6mZUo3fg'
-  };
-  t.same(actual, expected);
-});
-
-test('parse() figure + youtube iframe', t => {
-  const input = `<figure>
-    <iframe src="https://www.youtube.com/embed/pDVmldTurqk"></iframe>
-    <figcaption>Hello, <b>world</b></figcaption>
-  </figure>`;
-  const actual = parse(input);
-  const expected = {
-    type: 'youtube',
-    youtubeId: 'pDVmldTurqk'
   };
   t.same(actual, expected);
 });


### PR DESCRIPTION
Break out embeds implementation from html-to-article-json. In the future this repo will include render-methods as well - so you can both parse & render embeds!

R = @iefserge
T = major

TODO:
- [x] Travis
- [ ] Readme
- [ ] Update https://www.npmjs.com/package/html-to-article-json to use this repo
