### PR TITLE
Add support for Tumblr post embeds

### DIFF
--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -6,12 +6,13 @@ import * as instagram from './instagram';
 import * as facebook from './facebook';
 import * as vine from './vine';
 import * as spotify from './spotify';
+import * as tumblr from './tumblr';
 import * as custom from './custom';
 import assert from 'assert';
 import forEach from 'lodash.foreach';
 
 const types = {
-  image, video, youtube, twitter, instagram, facebook, vine, spotify,
+  image, video, youtube, twitter, instagram, facebook, vine, spotify, tumblr,
   custom /* last element */
 };
 

--- a/lib/types/tumblr.js
+++ b/lib/types/tumblr.js
@@ -1,0 +1,23 @@
+import parseText from '../parse-text';
+import renderText from '../render-text';
+import element from 'virtual-element';
+
+const type = 'tumblr';
+
+export const parse = ([elm]) => {
+  if (!elm.classList.contains('tumblr-post')) {
+    return null;
+  }
+
+  const did = elm.getAttribute('data-did');
+  const url = elm.getAttribute('data-href');
+  const text = parseText(elm);
+
+  return {type, did, url, text};
+};
+
+export const render = ({did, url, text}) =>
+  <div class='tumblr-post' data-href={url} data-did={did}>
+    {renderText(text)}
+  </div>
+;

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -9,5 +9,6 @@ export default {
   facebookPhoto: fs.readFileSync(`${__dirname}/facebook-photo.html`, 'utf8').trim(),
   facebookEmbedCode: fs.readFileSync(`${__dirname}/facebook-embed-code.html`, 'utf8').trim(),
   tweetNoUser: fs.readFileSync(`${__dirname}/tweet-no-user.html`, 'utf8').trim(),
-  tweetVideo: fs.readFileSync(`${__dirname}/tweet-video.html`, 'utf8').trim()
+  tweetVideo: fs.readFileSync(`${__dirname}/tweet-video.html`, 'utf8').trim(),
+  tumblrPost: fs.readFileSync(`${__dirname}/tumblr-post.html`, 'utf8').trim()
 };

--- a/test/fixtures/tumblr-post.html
+++ b/test/fixtures/tumblr-post.html
@@ -1,0 +1,1 @@
+<div class="tumblr-post" data-href="https://embed.tumblr.com/embed/post/8_SX4ALNOf1fYyEcjq78YQ/147291233392" data-did="7c08ba46cb75162284770cdee2a59365891a5e18"><a href="http://jencita.tumblr.com/post/147291233392/tswiftdaily-taylor-swift-at-lady-cilento">http://jencita.tumblr.com/post/147291233392/tswiftdaily-taylor-swift-at-lady-cilento</a></div>

--- a/test/html-parse-test.js
+++ b/test/html-parse-test.js
@@ -533,6 +533,21 @@ test('parse() iframe no src', t => {
   t.deepEqual(actual, expected);
 });
 
+test('parse() tumblr embed', t => {
+  const input = fixtures.tumblrPost;
+  const actual = parse(input);
+  const expected = {
+    type: 'tumblr',
+    did: '7c08ba46cb75162284770cdee2a59365891a5e18',
+    url: 'https://embed.tumblr.com/embed/post/8_SX4ALNOf1fYyEcjq78YQ/147291233392',
+    text: [{
+      content: 'http://jencita.tumblr.com/post/147291233392/tswiftdaily-taylor-swift-at-lady-cilento',
+      href: 'http://jencita.tumblr.com/post/147291233392/tswiftdaily-taylor-swift-at-lady-cilento'
+    }]
+  };
+  t.deepEqual(actual, expected);
+});
+
 test('parse() custom embed', t => {
   const input = '<iframe src="http://custom.com" width="600" height="600" frameborder="0"></iframe>';
   const actual = parse(input);

--- a/test/parse-render-test.js
+++ b/test/parse-render-test.js
@@ -50,3 +50,10 @@ test('parse() + render() instagram - without caption', t => {
   const actual = parseAndRender(input);
   t.is(actual, expected);
 });
+
+test('parse() + render() tumblr post', t => {
+  const input = fixtures.tumblrPost;
+  const expected = input;
+  const actual = parseAndRender(input);
+  t.is(actual, expected);
+});

--- a/test/render-test.js
+++ b/test/render-test.js
@@ -331,6 +331,21 @@ test('render() spotify, default size', t => {
   t.is(actual, expected);
 });
 
+test('render() tumblr', t => {
+  const input = {
+    type: 'tumblr',
+    did: '7c08ba46cb75162284770cdee2a59365891a5e18',
+    url: 'https://embed.tumblr.com/embed/post/8_SX4ALNOf1fYyEcjq78YQ/147291233392',
+    text: [{
+      content: 'http://jencita.tumblr.com/post/147291233392/tswiftdaily-taylor-swift-at-lady-cilento',
+      href: 'http://jencita.tumblr.com/post/147291233392/tswiftdaily-taylor-swift-at-lady-cilento'
+    }]
+  };
+  const actual = render(input);
+  const expected = fixtures.tumblrPost;
+  t.is(actual, expected);
+});
+
 test('renderText()', t => {
   t.deepEqual(renderText(undefined), []);
   t.deepEqual(renderText(null), []);


### PR DESCRIPTION
This adds support for parse() and render() for tumblr posts, including tests.
