### PR TITLE
run tests with tape-run

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "semistandard | snazzy",
     "test:node": "nyc babel-tape-runner test/*-test.js",
-    "test:browser": "browserify -t babelify -t brfs -d test/*-test.js | testron --errors | faucet",
+    "test:browser": "browserify -t babelify -t brfs -d test/*-test.js | tape-run | faucet",
     "test": "npm run test:node && npm run test:browser && npm run lint",
     "build": "rm -rf dist && mkdir -p dist && babel lib --out-dir dist",
     "watch": "rm -rf dist && mkdir -p dist && babel lib --out-dir dist --watch",
@@ -35,7 +35,6 @@
     "babelify": "^7.2.0",
     "brfs": "^1.4.3",
     "browserify": "^13.0.0",
-    "electron-prebuilt": "^0.37.7",
     "faucet": "0.0.1",
     "hyperscript": "^1.4.7",
     "nyc": "^7.0.0",
@@ -43,7 +42,7 @@
     "semistandard-deku": "micnews/semistandard#deku",
     "snazzy": "^4.0.0",
     "tape-catch": "^1.0.4",
-    "testron": "^1.2.0",
+    "tape-run": "^2.1.4",
     "tsml": "^1.0.1"
   },
   "dependencies": {

--- a/test/html-parse-test.js
+++ b/test/html-parse-test.js
@@ -70,7 +70,7 @@ test('parse() img with width & height', t => {
 });
 
 test('parse() img with width & height css', t => {
-  const input = tsml`<img src="http://example.com/image.jpg" style="width: 100; height: 200" />`;
+  const input = tsml`<img src="http://example.com/image.jpg" style="width: 100px; height: 200px" />`;
   const actual = parse(input);
   const expected = {
     type: 'image',
@@ -135,7 +135,7 @@ test('parse() video with width & height', t => {
 });
 
 test('parse() video with width & height css', t => {
-  const input = '<video src="http://example.com/video.mp4" style="width:100;height:200" />';
+  const input = '<video src="http://example.com/video.mp4" style="width:100px;height:200px" />';
   const actual = parse(input);
   const expected = {
     type: 'video',


### PR DESCRIPTION
Type: Patch
Review: @iefserge @kesla 

Updated to run browser tests with `tape-run` because our version of `electron-prebuilt` was outdated and I couldn't get `testron` to run with latest electron. 

Needed small update in tests to pass, without the `px` width and height would just be undefined. Tested this in chrome manually and actually saw the same behaviour there.  
