### PR TITLE
Make sure parsed input can be rendered and parsed again

### DIFF
--- a/lib/types/facebook.js
+++ b/lib/types/facebook.js
@@ -16,8 +16,8 @@ const parsePost = elm => {
   const pElm = elm.getElementsByTagName('p')[0];
   const text = parseText(pElm);
   const aElms = elm.getElementsByTagName('a') || [];
-  const user = aElms[0] ? aElms[0].childNodes[0].data : '';
-  const date = aElms[1] ? aElms[1].childNodes[0].data : '';
+  const user = aElms[0] && aElms[0].childNodes[0] ? aElms[0].childNodes[0].data : '';
+  const date = aElms[1] && aElms[1].childNodes[0] ? aElms[1].childNodes[0].data : '';
 
   return {embedAs, type, url, text, date, user};
 };
@@ -26,12 +26,12 @@ const parseVideo = elm => {
   const url = elm.getAttribute('data-href');
   const embedAs = 'video';
   const aElms = elm.getElementsByTagName('a') || [];
-  const headline = aElms[0] ? aElms[0].childNodes[0].data : '';
+  const headline = aElms[0] && aElms[0].childNodes[0] ? aElms[0].childNodes[0].data : '';
   const blockquoteElm = elm.getElementsByTagName('blockquote')[0];
   const date = blockquoteElm ? last(blockquoteElm.childNodes).data.replace(' on ', '') : '';
   const user = {
     url: aElms[1] && aElms[1].getAttribute('href') || '',
-    name: aElms[1] && aElms[1].childNodes[0].data || ''
+    name: aElms[1] && aElms[1].childNodes[0] && aElms[1].childNodes[0].data || ''
   };
   const pElm = elm.getElementsByTagName('p')[0];
   const text = parseText(pElm);

--- a/test/embed-code-parse-test.js
+++ b/test/embed-code-parse-test.js
@@ -1,6 +1,21 @@
 import test from './tape-wrapper';
 import {parseInput} from '../lib';
 import tsml from 'tsml';
+import {render, parse as _parse} from '../lib';
+import {renderString, tree} from 'deku';
+import queryDom from 'query-dom';
+
+
+const parse = process.browser
+  ? (str) => {
+    const node = document.createElement('div');
+    node.innerHTML = str;
+    return _parse(node.childNodes);
+  }
+  : str => _parse(queryDom(str));
+
+const renderAndParse = input =>
+  parse(renderString(tree(render(input))));
 
 test('parse invalid input', t => {
   t.is(parseInput(), null);
@@ -163,6 +178,11 @@ test('facebook', t => {
     expectedVideo
   );
 
+  t.equals(
+    renderAndParse(expectedVideo).url,
+    expectedVideo.url
+  );
+
   t.deepEqual(parseInput(postCode), expectedPost);
   t.deepEqual(
     parseInput('https://www.facebook.com/zuck/posts/10102593740125791'),
@@ -185,6 +205,11 @@ test('facebook', t => {
     expectedPost
   );
   t.deepEqual(parseInput('//facebook.com/zuck/posts/10102593740125791'), expectedPost);
+
+  t.equals(
+    renderAndParse(expectedPost).url,
+    expectedPost.url
+  );
 
   const expectedPagePhoto = {
     type: 'facebook',
@@ -214,6 +239,11 @@ test('facebook', t => {
     parseInput('//facebook.com/rewire.news/photos/a.102749171737.90216.9432926737/10152515593211738'),
     expectedPagePhoto);
 
+  t.equals(
+    renderAndParse(expectedPagePhoto).url,
+    expectedPagePhoto.url
+  );
+
   const expectedPhoto = {
     type: 'facebook',
     embedAs: 'photo',
@@ -233,6 +263,11 @@ test('facebook', t => {
   t.deepEqual(
     parseInput('https://www.facebook.com/photo.php?fbid=10103183415950711&set=pcb.10103183428221121&type=3&theater'),
     expectedPhoto);
+
+  t.equals(
+    renderAndParse(expectedPhoto).url,
+    expectedPhoto.url
+  );
 });
 
 test('youtube', t => {
@@ -264,6 +299,11 @@ test('youtube', t => {
   t.deepEqual(parseInput('https://youtu.be/I7IdS-PbEgI'), expected);
   t.deepEqual(parseInput('http://youtu.be/I7IdS-PbEgI'), expected);
   t.deepEqual(parseInput('//youtu.be/I7IdS-PbEgI'), expected);
+
+  t.equals(
+    renderAndParse(expected).youtubeId,
+    expected.youtubeId
+  );
 });
 
 test('twitter', t => {
@@ -314,6 +354,11 @@ test('twitter', t => {
     parseInput('//www.twitter.com/thomas_kast/status/709353211455541248'),
     expected
   );
+
+  t.equals(
+    renderAndParse(expected).url,
+    expected.url
+  );
 });
 
 test('tumblr', t => {
@@ -346,6 +391,11 @@ test('tumblr', t => {
     parseInput('//embed.tumblr.com/embed/post/Hj-X2tKsXur2oF91XMwT5w/105825530041'),
     expected
   );
+
+  t.equals(
+    renderAndParse(expected).url,
+    expected.url
+  );
 });
 
 test('vine', t => {
@@ -373,6 +423,11 @@ test('vine', t => {
   t.deepEqual(parseInput('//vine.co/v/iHTTDHz6Z2v'), expected);
   t.deepEqual(parseInput('//vine.co/v/iHTTDHz6Z2v/embed'), expected);
   t.deepEqual(parseInput('//vine.co/v/iHTTDHz6Z2v/embed/simple'), expected);
+
+  t.deepEqual(
+    renderAndParse(expected),
+    expected
+  );
 });
 
 test('imgur', t => {


### PR DESCRIPTION
I had an issue where I used an object created with `parseInput()` to render a facebook embed and when trying to `parse()` that rendered embed it would error. This PR fixes that issue and adds tests for the other defined types in here. 

Type: Patch
Review: @danmakenoise @iefserge 
