### PR TITLE
fix: use instagram embed url

### DIFF
--- a/lib/parse-input.js
+++ b/lib/parse-input.js
@@ -4,7 +4,7 @@ const allowed = [
     return {
       type: 'instagram',
       text: '',
-      url: `https://www.instagram.com/p/${id}`,
+      url: `https://www.instagram.com/p/${id}/embed`,
       id: id
     };
   }],


### PR DESCRIPTION
Instagram supports embedding images without javascript if you append `/embed` after the id.

To be honest first I read about this here: http://stackoverflow.com/a/24746208

I wasn't able to find any info about this in the developer docs unfortunately.:(

Probably this is a breaking change.